### PR TITLE
Less specific Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "npm run lint -- --fix"
   },
   "engines": {
-    "node": "^8.11.3",
+    "node": ">=8.11.3",
     "npm": ">=5.0.0"
   },
   "jest": {


### PR DESCRIPTION
Thanks for this library - I've been waiting for something like this!

I'm not sure what the reasoning is for the node version in the package.json – my Node version is 10.7.0 when developing locally, and this package fails to install.

This PR makes the required Node version more forgiving.