### PR TITLE
Added surface behaviour for cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Tailwind React UI's suite of components are highly composable allowing for a lar
 
 ```jsx
 <Box maxW="md" m={{ x: 'auto' }}>
-  <Box border shadow>
+  <Box border shadow bg="white">
     <Box p={4}>
       <Text is="h1" text={['blue', 'xxl']} m={{ b: 4 }}>
         Hello World

--- a/src/components/card/Card.jsx
+++ b/src/components/card/Card.jsx
@@ -4,8 +4,15 @@ import PropTypes from 'prop-types'
 import { withTheme } from '../theme'
 import { Box } from '../primitives'
 
-const Card = ({ is, children, theme, ...rest }) => (
-  <Box is={is} overflow="hidden" rounded={theme.radius} {...rest}>
+const Card = ({ is, children, theme, surface, ...rest }) => (
+  <Box
+    is={is}
+    overflow="hidden"
+    rounded={theme.radius}
+    bg={theme.surfaceColors[surface] || theme.brandColors[surface]}
+    text={surface !== 'default' ? theme.textColors.on[surface] : undefined}
+    {...rest}
+  >
     {children}
   </Box>
 )
@@ -14,11 +21,13 @@ Card.propTypes = {
   is: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
   theme: PropTypes.shape({}).isRequired,
   children: PropTypes.node,
+  surface: PropTypes.string,
 }
 
 Card.defaultProps = {
   is: 'section',
   children: undefined,
+  surface: 'default',
 }
 
 export { Card as component }

--- a/src/components/theme/defaultTheme.js
+++ b/src/components/theme/defaultTheme.js
@@ -44,7 +44,13 @@ export default {
       danger: 'white',
       warning: 'black',
       info: 'black',
+      dark: 'white',
     },
+  },
+  surfaceColors: {
+    default: 'white',
+    dark: 'grey-darker',
+    light: 'grey-lightest',
   },
   highlightOffset: 1,
   accentSize: 4,


### PR DESCRIPTION
Can supply `brandColors` or `surfaceColors` from theme to `surface` prop to apply background color and relevent text color